### PR TITLE
fix: enable edit button for Functions

### DIFF
--- a/function-editor.ts
+++ b/function-editor.ts
@@ -1841,7 +1841,6 @@ export default class FunctionEditor9030 extends LitElement {
         <nav>
           <mwc-icon-button
             icon="edit"
-            disabled
             @click="${() => this.openEditWizard(this.function!)}"
           >
           </mwc-icon-button>


### PR DESCRIPTION
* undo disabling of edit button for Functions (there is no edit button for Subfunctions, so this fix only applies to the edit button for Functions)